### PR TITLE
Added timestamp option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 20240405 (v0.0.16)
+
+Added `timeStamp` configuration option that when enabled adds a `timestamp` property to the new post's front matter with the current timestamp. Requested in [Time Support in Date Property](https://github.com/johnwargo/eleventy-new-post/issues/2).
+
 ## 20240218 (v0.0.15)
 
 Added a configuration option `promptTemplateFile` which configures the utility to prompt the user for the template file for the new post. Place one or more template files in the folder matching the file name `11ty-np*.*` and the utility will grab all of them and prompt the user (ignoring the `11ty-np.json` file because that's the config file and can't be used as a template).

--- a/eleventy-new-post.js
+++ b/eleventy-new-post.js
@@ -192,6 +192,7 @@ function buildConfigObject() {
         promptTargetFolder: false,
         promptTemplateFile: false,
         templateFile: TEMPLATE_FILE_DEFAULT,
+        timeStamp: false,
         useYear: false,
     };
 }
@@ -387,9 +388,13 @@ if (fs.existsSync(outputFile)) {
     log.info(`File ${outputFile} already exists, exiting`);
     process.exit(1);
 }
+templateFrontmatter.title = postTitle;
 let tmpDate = new Date();
 templateFrontmatter.date = `${tmpDate.getFullYear()}-${zeroPad(tmpDate.getMonth() + 1)}-${zeroPad(tmpDate.getDate())}`;
-templateFrontmatter.title = postTitle;
+if (configObject.timeStamp) {
+    log.debug('Adding timestamp to front matter');
+    templateFrontmatter.timestamp = tmpDate.toISOString();
+}
 if (configObject.promptCategory) {
     templateFrontmatter.categories = catList;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-new-post",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Generates a new Eleventy site post (with options)",
   "author": "John M. Wargo",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -206,6 +206,26 @@ categories:
 ---
 ```
 
+### `timeStamp`
+
+Eleventy has specific rules about how it uses a post file's `date` front matter property as described in [Content Dates](https://www.11ty.dev/docs/dates/). For the purpose of this particular setting, it's important to note that Eleventy only cares about the post date, not any timestamp associated with it. So if you put a timestamp in the front matter's `date` property that looks like this: `2024-04-05T21:15:35.719Z`, when you render the property on a page, Eleventy will only show the date portion.
+
+If you want to display a post creation time, you must add an additional property to the post's front matter.
+
+When you enable `timeStamp` in the configuration file (`"timeStamp: true`), the utility automatically adds the `timestamp` property to the post's front matter and sets it to the current date/time. You can then use that property to display both the post creation date and time in a site (and even include it in a RSS feed).
+
+```yaml
+---
+layout: default
+title: Added TimeStamp
+description: 
+date: 2024-04-05
+categories:
+  - People
+timestamp: 2024-04-05T21:21:09.591Z
+---
+```
+
 ### `useYear`
 
 Some Eleventy site projects store posts in a separate folder per year, some don't - it's a developer choice and this tool has to be flexible. This configuration property controls where the program stores generated post files. 

--- a/ts-src/eleventy-new-post.ts
+++ b/ts-src/eleventy-new-post.ts
@@ -38,6 +38,8 @@ type ConfigObject = {
   promptCategory: boolean;
   // added in 0.0.15
   promptTemplateFile: boolean;
+  // added in 0.0.16
+  timeStamp: boolean;
 }
 
 type ConfigValidation = {
@@ -272,6 +274,7 @@ function buildConfigObject(): ConfigObject {
     promptTargetFolder: false,
     promptTemplateFile: false,
     templateFile: TEMPLATE_FILE_DEFAULT,
+    timeStamp: false,
     useYear: false,
   }
 }
@@ -528,9 +531,14 @@ if (fs.existsSync(outputFile)) {
 }
 
 // update the front matter with the post title and category
+templateFrontmatter.title = postTitle;
 let tmpDate = new Date();
 templateFrontmatter.date = `${tmpDate.getFullYear()}-${zeroPad(tmpDate.getMonth() + 1)}-${zeroPad(tmpDate.getDate())}`;
-templateFrontmatter.title = postTitle;
+// added in 0.0.16
+if (configObject.timeStamp) {
+  log.debug('Adding timestamp to front matter');
+  templateFrontmatter.timestamp = tmpDate.toISOString();
+}
 
 if (configObject.promptCategory) {
   // add the category list to the document


### PR DESCRIPTION
Added new configuration option `timeStamp` which, when enabled, adds a `timestamp` property to the new post's front matter with the full timestamp (instead of just a date like what goes in the `date` property) 

Resolves #2 